### PR TITLE
removing online suffix in ram and gateways

### DIFF
--- a/src/components/CardList.svelte
+++ b/src/components/CardList.svelte
@@ -58,7 +58,7 @@
       {
         id: 6,
         data: data.totalMru,
-        title: "RAM Online",
+        title: "RAM",
         icon: "/assets/ram.svg",
       },
       {
@@ -70,7 +70,7 @@
       {
         id: 8,
         data: data.gateways + 8,
-        title: "Gateways Online",
+        title: "Gateways",
         icon: "/assets/gateways.svg",
       },
       {


### PR DESCRIPTION
### Description
Removing online suffix from rams and gateways cards.

### Related issues 
#27